### PR TITLE
Feat/15 ssh authentication

### DIFF
--- a/triton_dashboard/build.gradle
+++ b/triton_dashboard/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	// thymeleaf layout
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.4.0'
 
+	// SSH 연결 - Apache MINA SSHD Core
+	implementation 'org.apache.sshd:sshd-core:2.12.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/project/entity/Project.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/project/entity/Project.java
@@ -1,6 +1,7 @@
 package com.triton.msa.triton_dashboard.project.entity;
 
 import com.triton.msa.triton_dashboard.chat.entity.ChatHistory;
+import com.triton.msa.triton_dashboard.ssh.entity.SshInfo;
 import com.triton.msa.triton_dashboard.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/entity/SshInfo.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/entity/SshInfo.java
@@ -1,4 +1,4 @@
-package com.triton.msa.triton_dashboard.project.entity;
+package com.triton.msa.triton_dashboard.ssh;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Lob;

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/entity/SshInfo.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/entity/SshInfo.java
@@ -1,4 +1,4 @@
-package com.triton.msa.triton_dashboard.ssh;
+package com.triton.msa.triton_dashboard.ssh.entity;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Lob;
@@ -13,4 +13,6 @@ public class SshInfo {
     private String sshIpAddress;
     @Lob
     private String sshAuthKey;
+    private String hostname;
+    private int port;
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshService.java
@@ -1,0 +1,70 @@
+package com.triton.msa.triton_dashboard.ssh.service;
+
+import com.triton.msa.triton_dashboard.ssh.entity.SshInfo;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
+import org.springframework.stereotype.Service;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class SshService {
+
+    private static final long CONNECT_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
+    private static final long AUTH_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
+
+    public boolean testConnection(SshInfo sshInfo) {
+        if (sshInfo == null || sshInfo.getSshIpAddress() == null || sshInfo.getSshAuthKey() == null) {
+            return false;
+        }
+
+        try(SshClient client = SshClient.setUpDefaultClient()) {
+            client.start();
+
+            Path tempKeyFile = createTempKeyFile(sshInfo.getSshAuthKey());
+
+            FileKeyPairProvider keyPairProvider = new FileKeyPairProvider(tempKeyFile);
+            KeyPair keyPair = keyPairProvider.loadKeys(null).iterator().next();
+
+            try (ClientSession session = client.connect(sshInfo.getHostname(), sshInfo.getSshIpAddress(), sshInfo.getPort())
+                    .verify(CONNECT_TIMEOUT).getSession()) {
+                session.addPublicKeyIdentity(keyPair);
+
+                session.auth().verify(AUTH_TIMEOUT);
+
+                boolean isAuthenticated = session.isAuthenticated();
+                Files.delete(tempKeyFile);
+                return isAuthenticated;
+            }
+        }
+        catch (IOException ex) {
+            ex.printStackTrace();
+            return false;
+        }
+    }
+
+    private Path createTempKeyFile(String privateKey) throws IOException {
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+
+        Path tempFile = Files.createTempFile("ssh-key-", ".pem", attr);
+
+        try(FileOutputStream fos = new FileOutputStream(tempFile.toFile())) {
+            fos.write(privateKey.getBytes());
+        }
+
+        tempFile.toFile().deleteOnExit();
+
+        return tempFile;
+    }
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요

- 추후 SSH 인증을 위한 인증 로직 구현

# 어떻게 해결했나요

- SshInfo 도메인 속성 추가(연결 시 사용할 port, hostname)
- testConnection 로직 구현

# 어떤 부분에 집중하여 리뷰해야 할까요?

- testConnection 로직은 apache.sshd의 SshClient를 사용하여 구현했습니다.
- 추후 쓰레드 풀 고갈 문제를 고려해서 비동기 방식 도입 논의가 필요합니다.