### PR TITLE
Feat 17/private data upload

### DIFF
--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/controller/PrivateDataController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/controller/PrivateDataController.java
@@ -1,0 +1,47 @@
+package com.triton.msa.triton_dashboard.private_data.controller;
+
+import com.triton.msa.triton_dashboard.chat.service.ChatHistoryService;
+import com.triton.msa.triton_dashboard.private_data.dto.UploadResultDto;
+import com.triton.msa.triton_dashboard.private_data.service.PrivateDataService;
+import com.triton.msa.triton_dashboard.project.entity.Project;
+import com.triton.msa.triton_dashboard.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/projects/{projectId}/private-data")
+@RequiredArgsConstructor
+public class PrivateDataController {
+
+    private final PrivateDataService privateDataService;
+    private final ProjectService projectService;
+    // private final ChatHistoryService chatHistoryService;
+
+    @PostMapping("/upload")
+    public String uploadZip(
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("file") MultipartFile file,
+            Model model
+    ) {
+        UploadResultDto result;
+
+        try {
+            result = privateDataService.processZipFile(projectId, file);
+        } catch (IllegalArgumentException e) {
+            result = new UploadResultDto(e.getMessage(), List.of(), List.of());
+        }
+
+        Project project = projectService.getProject(projectId);
+
+        model.addAttribute("uploadResult", result);
+        model.addAttribute("project", project);
+        // model.addAttribute("history", chatHistoryService.getHistoryForProject(project));
+
+        return "projects/chat";
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/dto/UploadResultDto.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/dto/UploadResultDto.java
@@ -1,0 +1,9 @@
+package com.triton.msa.triton_dashboard.private_data.dto;
+
+import java.util.List;
+
+public record UploadResultDto (
+    String message,
+    List<String> savedFilenames,
+    List<String> skippedFilenames
+) {}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
@@ -1,0 +1,102 @@
+package com.triton.msa.triton_dashboard.private_data.service;
+
+import com.triton.msa.triton_dashboard.private_data.dto.UploadResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Service
+@RequiredArgsConstructor
+public class PrivateDataService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public UploadResultDto processZipFile(Long projectId, MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".zip")) {
+            throw new IllegalArgumentException("지원되지 않는 파일 형식입니다. .zip 파일만 업로드해주세요.");
+        }
+
+        try {
+            Path tempDir = Files.createTempDirectory("upload-zip");
+            List<ExtractedFile> extractedFiles = unzipToFileList(file.getInputStream(), tempDir);
+
+            List<String> saved = new ArrayList<>();
+            List<String> skipped = new ArrayList<>();
+
+            for (ExtractedFile doc : extractedFiles) {
+                if (isAllowed(doc.filename())) {
+                    saveToElasticsearch(projectId, doc);
+                    saved.add(doc.filename());
+                } else {
+                    skipped.add(doc.filename());
+                }
+            }
+
+            return new UploadResultDto("업로드 완료", saved, skipped);
+
+        } catch (IOException e) {
+            return new UploadResultDto("압축 해제 실패: " + e.getMessage(), List.of(), List.of());
+        }
+    }
+
+    private List<ExtractedFile> unzipToFileList(InputStream inputStream, Path targetDir) throws IOException {
+        List<ExtractedFile> files = new ArrayList<>();
+
+        try (ZipInputStream zis = new ZipInputStream((inputStream))) {
+            ZipEntry entry;
+
+            while ((entry = zis.getNextEntry()) != null) {
+                // 폴더는 스킵
+                if (entry.isDirectory()) continue;
+
+                // 압축 해제 대상 경로 구성
+                Path newFile = targetDir.resolve(entry.getName()).normalize();
+                if (!newFile.startsWith(targetDir)) throw new IOException("Zip Slip 공격 탑지됨");
+
+                Files.createDirectories(newFile.getParent());
+                Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
+
+                // 파일 내용 읽기
+                String content = Files.readAllLines(newFile).stream().collect(Collectors.joining("\n"));
+                files.add(new ExtractedFile(entry.getName(), content, Instant.now()));
+            }
+        }
+        return files;
+    }
+
+    private boolean isAllowed(String filename) {
+        String lower = filename.toLowerCase();
+        return !(lower.endsWith(".exe") || lower.endsWith(".sh") || lower.endsWith("bat"));
+    }
+
+    private void saveToElasticsearch(Long projectId, ExtractedFile file) {
+        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/doc";
+        String indexUrl = "http://localhost:30920/project-" + projectId + "/_doc";
+
+        Map<String, Object> documnet = Map.of(
+                "filename", file.filename(),
+                "content", file.content(),
+                "timestamp", file.timestamp().toString()
+        );
+
+        restTemplate.postForEntity(indexUrl, documnet, String.class);
+    }
+
+    private record ExtractedFile(String filename, String content, Instant timestamp) {}
+}
+

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
@@ -32,6 +32,7 @@ public class PrivateDataService {
         }
 
         try {
+            // 압축 해제를 위한 임시 디렉토리 생성
             Path tempDir = Files.createTempDirectory("upload-zip");
             List<ExtractedFile> extractedFiles = unzipToFileList(file.getInputStream(), tempDir);
 
@@ -71,7 +72,7 @@ public class PrivateDataService {
                 Files.createDirectories(newFile.getParent());
                 Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
 
-                // 파일 내용 읽기
+                // Elasticsearch 저장을 위해 파일 내용을 하나의 문자열로 합침
                 String content = Files.readAllLines(newFile).stream().collect(Collectors.joining("\n"));
                 files.add(new ExtractedFile(entry.getName(), content, Instant.now()));
             }
@@ -85,7 +86,7 @@ public class PrivateDataService {
     }
 
     private void saveToElasticsearch(Long projectId, ExtractedFile file) {
-        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/doc";
+        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/_doc";
         String indexUrl = "http://localhost:30920/project-" + projectId + "/_doc";
 
         Map<String, Object> documnet = Map.of(

--- a/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
+++ b/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
@@ -23,6 +23,13 @@
                th:href="@{/projects/{id}/history(id=${project.id})}">
                 <i class="bi bi-clock-history me-2"></i>작업 이력 조회
             </a>
+
+            <!--추가됨-->
+            <a class="list-group-item list-group-item-action list-group-item-light p-3"
+               th:href="|@{/projects/{id}/chat(id=${project.id})}#zip-upload|">
+            <i class="bi bi-upload me-2"></i>비공개 데이터 업로드
+            </a>
+
             <hr class="my-2"/>
             <a class="list-group-item list-group-item-action list-group-item-light p-3"
                th:href="@{/projects}">

--- a/triton_dashboard/src/main/resources/templates/projects/chat.html
+++ b/triton_dashboard/src/main/resources/templates/projects/chat.html
@@ -48,6 +48,38 @@
             </div>
         </form>
     </div>
+
+    <!-- ZIP 업로드 UI 추가 -->
+    <div id="zip-upload" class="card mt-5">
+        <div class="card-header">비공개 ZIP 데이터 업로드</div>
+        <div class="card-body">
+            <form th:action="@{/projects/{id}/private-data/upload(id=${project.id})}" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <input type="file" name="file" accept=".zip" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-success">업로드</button>
+            </form>
+
+            <!-- 업로드 결과 메시지 -->
+            <div th:if="${uploadResult != null}" class="alert alert-info mt-4">
+                <h5 th:text="${uploadResult.message}">업로드 결과</h5>
+
+                <div th:if="${uploadResult.savedFilenames.size() > 0}">
+                    <strong>저장된 파일:</strong>
+                    <ul>
+                        <li th:each="f : ${uploadResult.savedFilenames}" th:text="${f}"></li>
+                    </ul>
+                </div>
+
+                <div th:if="${uploadResult.skippedFilenames.size() > 0}">
+                    <strong>필터링된 파일:</strong>
+                    <ul>
+                        <li th:each="f : ${uploadResult.skippedFilenames}" th:text="${f}"></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
 </section>
 
 </body>


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요
- 사용자가 프로젝트별로 비공개 .zip 데이터를 업로드하면, 파일들 내용을 Elasticsearch에 저장
- 업로드된 zip 파일은 스프링 서버에서 압축 해제되며, .exe, .sh 등 위험 확장자는 필터링되어 제외
- 유효한 파일의 내용은 Elasticsearch에 저장되어 향후 RAG 기반 명세 생성, 검색 등에 활용 가능
- 비공개 데이터 업로드를 위한 UI 추가

# 어떻게 해결했나요
- private_data 패키지에 controller, service, dto 구성
- MultipartFile을 통해 사용자 파일을 입력 받아 ZipInputStream으로 압축 해제
- 파일 확장자를 검사하고, 안전한 파일만 Elasticsearch에 POST /project-{id}/_doc 형태로 저장
- sidebar.html과 chat.html 에 업로드 섹션 추가해 비공개 데이터 업로드를 위한 UI 추가
- 에러 방지를 위해 Zip Slip 공격 방지 로직 포함 (normalize 경로 검사)
- Zip Slip은 악성 ZIP 파일이 "../../../etc/passwd" 같은 경로를 포함한 파일명을 가지는 경우, 압축 해제 시 시스템 디렉터리까지 침투하여 중요 파일을 덮어쓰거나 악성코드를 주입할 수 있는 보안 취약점입니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- t2.micro가 성능이 너무 안좋아서 Elasticsearch를 버티지 못하고 뻗어버립니다. 그래서 나중에 OCI로 옮겨야 할 것 같습니다. 그래서 일단은 인스턴스 중단 시켜놨고, 테스트는 로컬로 했습니다. 그래서 현재 Elasticsearch url은 로컬 url로 되어 있습니다.
- 비공개 데이터 사용자 입력을 받고, 압축 해제 후 저장할 때 예외 처리가 충분히 되었는지
- RAG에서 향후 조회할 때 잘 조회가 되는지