### PR TITLE
Feat 19/api key verification

### DIFF
--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/config/SecurityConfig.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**")
                 .permitAll()
-                .requestMatchers("/", "/register", "/login")
+                .requestMatchers("/", "/register", "/login", "/validate-api-key")
                 .permitAll()
                 .requestMatchers("/h2-console/**")
                 .permitAll()
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .permitAll()
         )
         .csrf(csrf -> csrf
-                .ignoringRequestMatchers("/h2-console/**"))
+                .ignoringRequestMatchers("/h2-console/**", "/validate-api-key"))
         .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
 
         return http.build();

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/controller/PrivateDataController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/controller/PrivateDataController.java
@@ -1,0 +1,47 @@
+package com.triton.msa.triton_dashboard.private_data.controller;
+
+import com.triton.msa.triton_dashboard.chat.service.ChatHistoryService;
+import com.triton.msa.triton_dashboard.private_data.dto.UploadResultDto;
+import com.triton.msa.triton_dashboard.private_data.service.PrivateDataService;
+import com.triton.msa.triton_dashboard.project.entity.Project;
+import com.triton.msa.triton_dashboard.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/projects/{projectId}/private-data")
+@RequiredArgsConstructor
+public class PrivateDataController {
+
+    private final PrivateDataService privateDataService;
+    private final ProjectService projectService;
+    // private final ChatHistoryService chatHistoryService;
+
+    @PostMapping("/upload")
+    public String uploadZip(
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("file") MultipartFile file,
+            Model model
+    ) {
+        UploadResultDto result;
+
+        try {
+            result = privateDataService.processZipFile(projectId, file);
+        } catch (IllegalArgumentException e) {
+            result = new UploadResultDto(e.getMessage(), List.of(), List.of());
+        }
+
+        Project project = projectService.getProject(projectId);
+
+        model.addAttribute("uploadResult", result);
+        model.addAttribute("project", project);
+        // model.addAttribute("history", chatHistoryService.getHistoryForProject(project));
+
+        return "projects/chat";
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/dto/UploadResultDto.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/dto/UploadResultDto.java
@@ -1,0 +1,9 @@
+package com.triton.msa.triton_dashboard.private_data.dto;
+
+import java.util.List;
+
+public record UploadResultDto (
+    String message,
+    List<String> savedFilenames,
+    List<String> skippedFilenames
+) {}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
@@ -1,0 +1,102 @@
+package com.triton.msa.triton_dashboard.private_data.service;
+
+import com.triton.msa.triton_dashboard.private_data.dto.UploadResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+@Service
+@RequiredArgsConstructor
+public class PrivateDataService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public UploadResultDto processZipFile(Long projectId, MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".zip")) {
+            throw new IllegalArgumentException("지원되지 않는 파일 형식입니다. .zip 파일만 업로드해주세요.");
+        }
+
+        try {
+            Path tempDir = Files.createTempDirectory("upload-zip");
+            List<ExtractedFile> extractedFiles = unzipToFileList(file.getInputStream(), tempDir);
+
+            List<String> saved = new ArrayList<>();
+            List<String> skipped = new ArrayList<>();
+
+            for (ExtractedFile doc : extractedFiles) {
+                if (isAllowed(doc.filename())) {
+                    saveToElasticsearch(projectId, doc);
+                    saved.add(doc.filename());
+                } else {
+                    skipped.add(doc.filename());
+                }
+            }
+
+            return new UploadResultDto("업로드 완료", saved, skipped);
+
+        } catch (IOException e) {
+            return new UploadResultDto("압축 해제 실패: " + e.getMessage(), List.of(), List.of());
+        }
+    }
+
+    private List<ExtractedFile> unzipToFileList(InputStream inputStream, Path targetDir) throws IOException {
+        List<ExtractedFile> files = new ArrayList<>();
+
+        try (ZipInputStream zis = new ZipInputStream((inputStream))) {
+            ZipEntry entry;
+
+            while ((entry = zis.getNextEntry()) != null) {
+                // 폴더는 스킵
+                if (entry.isDirectory()) continue;
+
+                // 압축 해제 대상 경로 구성
+                Path newFile = targetDir.resolve(entry.getName()).normalize();
+                if (!newFile.startsWith(targetDir)) throw new IOException("Zip Slip 공격 탑지됨");
+
+                Files.createDirectories(newFile.getParent());
+                Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
+
+                // 파일 내용 읽기
+                String content = Files.readAllLines(newFile).stream().collect(Collectors.joining("\n"));
+                files.add(new ExtractedFile(entry.getName(), content, Instant.now()));
+            }
+        }
+        return files;
+    }
+
+    private boolean isAllowed(String filename) {
+        String lower = filename.toLowerCase();
+        return !(lower.endsWith(".exe") || lower.endsWith(".sh") || lower.endsWith("bat"));
+    }
+
+    private void saveToElasticsearch(Long projectId, ExtractedFile file) {
+        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/doc";
+        String indexUrl = "http://localhost:30920/project-" + projectId + "/_doc";
+
+        Map<String, Object> documnet = Map.of(
+                "filename", file.filename(),
+                "content", file.content(),
+                "timestamp", file.timestamp().toString()
+        );
+
+        restTemplate.postForEntity(indexUrl, documnet, String.class);
+    }
+
+    private record ExtractedFile(String filename, String content, Instant timestamp) {}
+}
+

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/private_data/service/PrivateDataService.java
@@ -32,6 +32,7 @@ public class PrivateDataService {
         }
 
         try {
+            // 압축 해제를 위한 임시 디렉토리 생성
             Path tempDir = Files.createTempDirectory("upload-zip");
             List<ExtractedFile> extractedFiles = unzipToFileList(file.getInputStream(), tempDir);
 
@@ -71,7 +72,7 @@ public class PrivateDataService {
                 Files.createDirectories(newFile.getParent());
                 Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
 
-                // 파일 내용 읽기
+                // Elasticsearch 저장을 위해 파일 내용을 하나의 문자열로 합침
                 String content = Files.readAllLines(newFile).stream().collect(Collectors.joining("\n"));
                 files.add(new ExtractedFile(entry.getName(), content, Instant.now()));
             }
@@ -85,7 +86,7 @@ public class PrivateDataService {
     }
 
     private void saveToElasticsearch(Long projectId, ExtractedFile file) {
-        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/doc";
+        // String indexUrl = "http://54.253.214.14:9200/project-" + projectId + "/_doc";
         String indexUrl = "http://localhost:30920/project-" + projectId + "/_doc";
 
         Map<String, Object> documnet = Map.of(

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
@@ -2,20 +2,20 @@ package com.triton.msa.triton_dashboard.user.controller;
 
 import com.triton.msa.triton_dashboard.user.dto.UserRegistrationDto;
 import com.triton.msa.triton_dashboard.user.service.UserService;
+import com.triton.msa.triton_dashboard.user.util.LlmApiKeyValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+    private final LlmApiKeyValidator llmApiKeyValidator;
 
     @GetMapping()
     public String root() {

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.triton.msa.triton_dashboard.user.controller;
 
 import com.triton.msa.triton_dashboard.user.dto.UserRegistrationDto;
-import com.triton.msa.triton_dashboard.user.entity.LlmModel;
 import com.triton.msa.triton_dashboard.user.service.UserService;
 import com.triton.msa.triton_dashboard.user.util.LlmApiKeyValidator;
 import jakarta.validation.Valid;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
-    private final LlmApiKeyValidator llmApiKeyValidator;
+    private final LlmApiKeyValidator apiKeyValidator;
 
     @GetMapping()
     public String root() {
@@ -49,14 +48,12 @@ public class UserController {
 
     @PostMapping("/validate-api-key")
     @ResponseBody
-    public ResponseEntity<?> validateApiKey(@RequestBody ApiKeyValidationRequest request) {
+    public ResponseEntity<String> validateApiKey(@RequestBody UserRegistrationDto registrationDto) {
         try {
-            llmApiKeyValidator.validate(request.apiKey(), request.model());
+            apiKeyValidator.validate(registrationDto.aiServiceApiKey(), registrationDto.llmModel());
             return ResponseEntity.ok().body("valid");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
     }
-
-    public record ApiKeyValidationRequest(String apiKey, LlmModel model) {}
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.triton.msa.triton_dashboard.user.controller;
 
 import com.triton.msa.triton_dashboard.user.dto.UserRegistrationDto;
+import com.triton.msa.triton_dashboard.user.entity.LlmModel;
 import com.triton.msa.triton_dashboard.user.service.UserService;
 import com.triton.msa.triton_dashboard.user.util.LlmApiKeyValidator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -43,4 +46,17 @@ public class UserController {
         userService.registerNewUser(registrationDto);
         return "redirect:/login/?success";
     }
+
+    @PostMapping("/validate-api-key")
+    @ResponseBody
+    public ResponseEntity<?> validateApiKey(@RequestBody ApiKeyValidationRequest request) {
+        try {
+            llmApiKeyValidator.validate(request.apiKey(), request.model());
+            return ResponseEntity.ok().body("valid");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        }
+    }
+
+    public record ApiKeyValidationRequest(String apiKey, LlmModel model) {}
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/dto/UserRegistrationDto.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/dto/UserRegistrationDto.java
@@ -14,7 +14,7 @@ public record UserRegistrationDto(
     private final static String DEFAULT_USERNAME = "user_default";
     private final static String DEFAULT_PASSWORD = "";
     private final static String DEFAULT_AISERVICEAPIKEY = "ai service key";
-    private final static LlmModel DEFAULT_LLMMODEL = LlmModel.OPENAI;
+    private final static LlmModel DEFAULT_LLMMODEL = LlmModel.GPT_4O;
 
     public static UserRegistrationDto getEmpty() {
         return new UserRegistrationDto(

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/dto/UserRegistrationDto.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/dto/UserRegistrationDto.java
@@ -1,5 +1,6 @@
 package com.triton.msa.triton_dashboard.user.dto;
 
+import com.triton.msa.triton_dashboard.user.entity.LlmModel;
 import jakarta.validation.constraints.NotEmpty;
 
 public record UserRegistrationDto(
@@ -7,17 +8,20 @@ public record UserRegistrationDto(
         String username,
         @NotEmpty
         String password,
-        String aiServiceApiKey
+        String aiServiceApiKey,
+        LlmModel llmModel
 ) {
     private final static String DEFAULT_USERNAME = "user_default";
     private final static String DEFAULT_PASSWORD = "";
     private final static String DEFAULT_AISERVICEAPIKEY = "ai service key";
+    private final static LlmModel DEFAULT_LLMMODEL = LlmModel.OPENAI;
 
     public static UserRegistrationDto getEmpty() {
         return new UserRegistrationDto(
                 DEFAULT_USERNAME,
                 DEFAULT_PASSWORD,
-                DEFAULT_AISERVICEAPIKEY
+                DEFAULT_AISERVICEAPIKEY,
+                DEFAULT_LLMMODEL
         );
     }
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/ApiKeyInfo.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/ApiKeyInfo.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 public class ApiKeyInfo {
 
     private String apiServiceApiKey;
-
+    private LlmModel llmModel;
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/ApiKeyInfo.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/ApiKeyInfo.java
@@ -1,6 +1,8 @@
 package com.triton.msa.triton_dashboard.user.entity;
 
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,5 +12,7 @@ import lombok.Setter;
 public class ApiKeyInfo {
 
     private String apiServiceApiKey;
+
+    @Enumerated(EnumType.STRING)
     private LlmModel llmModel;
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmModel.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmModel.java
@@ -1,18 +1,27 @@
 package com.triton.msa.triton_dashboard.user.entity;
 
 public enum LlmModel {
-    OPENAI("gpt-3.5-turbo"),
-    CLAUDE("claude-instant-1"),
-    GEMINI("gemini-pro"),
-    GROK("grok-1");
+    GPT_4O("gpt-4o", LlmProvider.OPENAI),
+    GPT_3_5("gpt-3.5-turbo", LlmProvider.OPENAI),
+    CLAUDE_3_OPUS("claude-3-opus", LlmProvider.ANTHROPIC),
+    CLAUDE_3_HAIKU("claude-3-haiku", LlmProvider.ANTHROPIC),
+    GEMINI_15_FLASH("gemini-1.5-flash", LlmProvider.GOOGLE),
+    GEMINI_PRO("gemini-pro", LlmProvider.GOOGLE),
+    GROK_1("grok-1", LlmProvider.GROK);
 
-    private final String defaultModelName;
+    private final String modelName;
+    private final LlmProvider provider;
 
-    LlmModel(String defaultModelName) {
-        this.defaultModelName = defaultModelName;
+    LlmModel(String modelName, LlmProvider provider) {
+        this.modelName = modelName;
+        this.provider = provider;
     }
 
-    public String getDefaultModelName() {
-        return defaultModelName;
+    public String getModelName() {
+        return modelName;
+    }
+
+    public LlmProvider getProvider() {
+        return provider;
     }
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmModel.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmModel.java
@@ -1,0 +1,18 @@
+package com.triton.msa.triton_dashboard.user.entity;
+
+public enum LlmModel {
+    OPENAI("gpt-3.5-turbo"),
+    CLAUDE("claude-instant-1"),
+    GEMINI("gemini-pro"),
+    GROK("grok-1");
+
+    private final String defaultModelName;
+
+    LlmModel(String defaultModelName) {
+        this.defaultModelName = defaultModelName;
+    }
+
+    public String getDefaultModelName() {
+        return defaultModelName;
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmProvider.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/entity/LlmProvider.java
@@ -1,0 +1,8 @@
+package com.triton.msa.triton_dashboard.user.entity;
+
+public enum LlmProvider {
+    OPENAI,
+    ANTHROPIC,
+    GOOGLE,
+    GROK
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/service/UserServiceImpl.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/service/UserServiceImpl.java
@@ -5,7 +5,6 @@ import com.triton.msa.triton_dashboard.user.entity.ApiKeyInfo;
 import com.triton.msa.triton_dashboard.user.entity.User;
 import com.triton.msa.triton_dashboard.user.entity.UserRole;
 import com.triton.msa.triton_dashboard.user.repository.UserRepository;
-import com.triton.msa.triton_dashboard.user.util.LlmApiKeyValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,19 +22,15 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final LlmApiKeyValidator apiKeyValidator;
 
     @Override
     @Transactional
     public User registerNewUser(UserRegistrationDto registrationDto) {
-        apiKeyValidator.validate(registrationDto.aiServiceApiKey(), registrationDto.llmModel());
-
         ApiKeyInfo apiKeyInfo = new ApiKeyInfo();
         apiKeyInfo.setApiServiceApiKey(registrationDto.aiServiceApiKey());
         apiKeyInfo.setLlmModel(registrationDto.llmModel());
 
         User user = new User();
-
         user.setUsername(registrationDto.username());
         user.setPassword(passwordEncoder.encode(registrationDto.password()));
         user.setApiKeyInfo(apiKeyInfo);

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/LlmApiKeyValidator.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/LlmApiKeyValidator.java
@@ -50,10 +50,26 @@ public class LlmApiKeyValidator {
 
             if (!response.getStatusCode().is2xxSuccessful()
                     || (responseBody != null && responseBody.contains("\"error\""))) {
-                throw new IllegalArgumentException("API 키 인증 실패: " + responseBody);
+
+                String shortMsg = "API 키 인증 실패";
+                String detailed = responseBody.length() > 200 ? responseBody.substring(0, 200) + "..." : responseBody;
+                throw new IllegalArgumentException(shortMsg + "\n상세: " + detailed);
             }
         } catch (Exception e) {
-            throw new IllegalArgumentException("API 키 요청 실패: " + e.getMessage());
+            throw new IllegalArgumentException("API 키 요청 실패: " + summaryErrorMsg(e.getMessage()) + "\n상세: " + e.getMessage());
+        }
+
+    }
+
+    private String summaryErrorMsg(String rawErrorMessage) {
+        if (rawErrorMessage.contains("Too Many Requests")) {
+            return "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.";
+        } else if (rawErrorMessage.contains("401")) {
+            return "API 키가 유효하지 않습니다.";
+        } else if (rawErrorMessage.contains("insufficient_quota")) {
+            return "API 사용 할당량이 초과되었습니다.";
+        } else {
+            return "알 수 없는 오류가 발생했습니다.";
         }
     }
 

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/LlmApiKeyValidator.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/LlmApiKeyValidator.java
@@ -1,0 +1,72 @@
+package com.triton.msa.triton_dashboard.user.util;
+
+import com.triton.msa.triton_dashboard.user.entity.LlmModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class LlmApiKeyValidator {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void validate(String apiKey, LlmModel model) {
+        String endpoint = switch (model) {
+            case OPENAI -> "https://api.openai.com/v1/chat/completions";
+            case CLAUDE -> "https://api.anthropic.com/v1/messages";
+            case GEMINI -> "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent";
+            case GROK -> "https://api.grok.xyz/v1/chat"; // 가정
+        };
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + apiKey);
+        if (model == LlmModel.CLAUDE) {
+            headers.set("anthropic-version", "2023-06-01");
+        }
+
+        String body = getTestBody(model);
+
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(endpoint, entity, String.class);
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new IllegalArgumentException("API 키 인증 실패: " + response.getStatusCode());
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("API 키 요청 실패: " + e.getMessage());
+        }
+    }
+
+    private String getTestBody(LlmModel model) {
+        return switch (model) {
+            case OPENAI, GROK -> """
+                {
+                  "model": "%s",
+                  "messages": [{"role": "user", "content": "ping"}],
+                  "temperature": 0.1
+                }
+            """.formatted(model.getDefaultModelName());
+
+            case CLAUDE -> """
+                {
+                  "model": "%s",
+                  "messages": [{"role": "user", "content": "ping"}],
+                  "max_tokens": 10
+                }
+            """.formatted(model.getDefaultModelName());
+
+            case GEMINI -> """
+                {
+                  "contents": [{"parts": [{"text": "ping"}]}]
+                }
+            """;
+        };
+    }
+}

--- a/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
+++ b/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
@@ -23,6 +23,13 @@
                th:href="@{/projects/{id}/history(id=${project.id})}">
                 <i class="bi bi-clock-history me-2"></i>작업 이력 조회
             </a>
+
+            <!--추가됨-->
+            <a class="list-group-item list-group-item-action list-group-item-light p-3"
+               th:href="|@{/projects/{id}/chat(id=${project.id})}#zip-upload|">
+            <i class="bi bi-upload me-2"></i>비공개 데이터 업로드
+            </a>
+
             <hr class="my-2"/>
             <a class="list-group-item list-group-item-action list-group-item-light p-3"
                th:href="@{/projects}">

--- a/triton_dashboard/src/main/resources/templates/projects/chat.html
+++ b/triton_dashboard/src/main/resources/templates/projects/chat.html
@@ -48,6 +48,38 @@
             </div>
         </form>
     </div>
+
+    <!-- ZIP 업로드 UI 추가 -->
+    <div id="zip-upload" class="card mt-5">
+        <div class="card-header">비공개 ZIP 데이터 업로드</div>
+        <div class="card-body">
+            <form th:action="@{/projects/{id}/private-data/upload(id=${project.id})}" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <input type="file" name="file" accept=".zip" class="form-control" required>
+                </div>
+                <button type="submit" class="btn btn-success">업로드</button>
+            </form>
+
+            <!-- 업로드 결과 메시지 -->
+            <div th:if="${uploadResult != null}" class="alert alert-info mt-4">
+                <h5 th:text="${uploadResult.message}">업로드 결과</h5>
+
+                <div th:if="${uploadResult.savedFilenames.size() > 0}">
+                    <strong>저장된 파일:</strong>
+                    <ul>
+                        <li th:each="f : ${uploadResult.savedFilenames}" th:text="${f}"></li>
+                    </ul>
+                </div>
+
+                <div th:if="${uploadResult.skippedFilenames.size() > 0}">
+                    <strong>필터링된 파일:</strong>
+                    <ul>
+                        <li th:each="f : ${uploadResult.skippedFilenames}" th:text="${f}"></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
 </section>
 
 </body>

--- a/triton_dashboard/src/main/resources/templates/register.html
+++ b/triton_dashboard/src/main/resources/templates/register.html
@@ -28,7 +28,7 @@
           <div class="mb-3">
             <label for="llmModel" class="form-label">LLM 모델 선택</label>
             <select class="form-select" id="llmModel" name="llmModel" required>
-              <option value="" disabled selected>모델 선택</option>
+              <option value="" disabled hidden selected>모델 선택</option>
               <option value="OPENAI">OpenAI GPT</option>
               <option value="CLAUDE">Claude</option>
               <option value="GEMINI">Gemini</option>
@@ -68,6 +68,7 @@
               statusEl.innerText = '❌ API 키와 모델을 모두 입력하세요';
               statusEl.style.color = 'red';
               submitBtn.disabled = true;
+
               return;
             }
 
@@ -80,12 +81,14 @@
               const res = await fetch('/validate-api-key', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ apiKey, model })
+                body: JSON.stringify({
+                  aiServiceApiKey: apiKey,
+                  llmModel: model
+                })
               });
 
               const text = await res.text();
-              console.log("응답 상태:", res.status);
-              console.log("응답 본문:", text);
+
               if (res.ok) {
                 statusEl.innerText = '✅ API 키 검증 성공';
                 statusEl.style.color = 'green';

--- a/triton_dashboard/src/main/resources/templates/register.html
+++ b/triton_dashboard/src/main/resources/templates/register.html
@@ -27,25 +27,81 @@
           <h5 class="mt-4">AI Service 설정</h5>
           <div class="mb-3">
             <label for="llmModel" class="form-label">LLM 모델 선택</label>
-            <select class="form-select" th:field="*{llmModel}" required>
-              <option value="" disabled selected>모델을 선택하세요</option>
+            <select class="form-select" id="llmModel" name="llmModel" required>
+              <option value="" disabled selected>모델 선택</option>
               <option value="OPENAI">OpenAI GPT</option>
-              <option value="CLAUDE">Anthropic Claude</option>
-              <option value="GEMINI">Google Gemini</option>
-              <option value="GROK">xAI Grok</option>
+              <option value="CLAUDE">Claude</option>
+              <option value="GEMINI">Gemini</option>
+              <option value="GROK">Grok</option>
             </select>
           </div>
 
           <div class="mb-3">
             <label for="aiServiceApiKey" class="form-label">API Key</label>
-            <input type="password" class="form-control" th:field="*{aiServiceApiKey}" required>
+            <input type="password" class="form-control" id="aiServiceApiKey" name="aiServiceApiKey" required>
           </div>
 
-          <button type="submit" class="btn btn-primary w-100">Register</button>
+          <div class="mb-3 d-flex gap-2">
+            <button type="button" id="validateKeyBtn" class="btn btn-outline-primary">API 키 검증</button>
+            <span id="keyStatus" class="align-self-center"></span>
+          </div>
+
+          <button type="submit" class="btn btn-primary w-100" id="submitBtn" disabled>Register</button>
+
+          <!--<button type="submit" class="btn btn-primary w-100">Register</button>-->
+
           <div class="text-center mt-3">
             <a th:href="@{/login}">이미 계정이 있으신가요? 로그인</a>
           </div>
         </form>
+
+        <script>
+          const validateBtn = document.getElementById('validateKeyBtn');
+          const submitBtn = document.getElementById('submitBtn');
+          const statusEl = document.getElementById('keyStatus');
+
+          validateBtn.addEventListener('click', async () => {
+            const apiKey = document.getElementById('aiServiceApiKey').value;
+            const model = document.getElementById('llmModel').value;
+
+            if (!apiKey || !model) {
+              statusEl.innerText = '❌ API 키와 모델을 모두 입력하세요';
+              statusEl.style.color = 'red';
+              submitBtn.disabled = true;
+              return;
+            }
+
+            // 초기화
+            statusEl.innerText = '검증 중...';
+            statusEl.style.color = 'black';
+            submitBtn.disabled = true;
+
+            try {
+              const res = await fetch('/validate-api-key', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ apiKey, model })
+              });
+
+              const text = await res.text();
+              console.log("응답 상태:", res.status);
+              console.log("응답 본문:", text);
+              if (res.ok) {
+                statusEl.innerText = '✅ API 키 검증 성공';
+                statusEl.style.color = 'green';
+                submitBtn.disabled = false;
+              } else {
+                statusEl.innerText = '❌ 실패: ' + text;
+                statusEl.style.color = 'red';
+                submitBtn.disabled = true;
+              }
+            } catch (e) {
+              statusEl.innerText = '❌ 네트워크 오류';
+              statusEl.style.color = 'red';
+              submitBtn.disabled = true;
+            }
+          });
+        </script>
       </div>
     </div>
   </div>

--- a/triton_dashboard/src/main/resources/templates/register.html
+++ b/triton_dashboard/src/main/resources/templates/register.html
@@ -24,10 +24,21 @@
             <input type="password" class="form-control" th:field="*{password}" required>
           </div>
 
-          <h5 class="mt-4">AI Service Key</h5>
+          <h5 class="mt-4">AI Service 설정</h5>
+          <div class="mb-3">
+            <label for="llmModel" class="form-label">LLM 모델 선택</label>
+            <select class="form-select" th:field="*{llmModel}" required>
+              <option value="" disabled selected>모델을 선택하세요</option>
+              <option value="OPENAI">OpenAI GPT</option>
+              <option value="CLAUDE">Anthropic Claude</option>
+              <option value="GEMINI">Google Gemini</option>
+              <option value="GROK">xAI Grok</option>
+            </select>
+          </div>
+
           <div class="mb-3">
             <label for="aiServiceApiKey" class="form-label">API Key</label>
-            <input type="password" class="form-control" th:field="*{aiServiceApiKey}">
+            <input type="password" class="form-control" th:field="*{aiServiceApiKey}" required>
           </div>
 
           <button type="submit" class="btn btn-primary w-100">Register</button>

--- a/triton_dashboard/src/main/resources/templates/register.html
+++ b/triton_dashboard/src/main/resources/templates/register.html
@@ -29,10 +29,13 @@
             <label for="llmModel" class="form-label">LLM 모델 선택</label>
             <select class="form-select" id="llmModel" name="llmModel" required>
               <option value="" disabled hidden selected>모델 선택</option>
-              <option value="OPENAI">OpenAI GPT</option>
-              <option value="CLAUDE">Claude</option>
-              <option value="GEMINI">Gemini</option>
-              <option value="GROK">Grok</option>
+              <option value="GPT_4O">OpenAI - gpt-4o</option>
+              <option value="GPT_3_5">OpenAI - gpt-3.5-turbo</option>
+              <option value="CLAUDE_3_OPUS">Anthropic - claude-3-opus</option>
+              <option value="CLAUDE_3_HAIKU">Anthropic - claude-3-haiku</option>
+              <option value="GEMINI_15_FLASH">Google - gemini-1.5-flash</option>
+              <option value="GEMINI_PRO">Google - gemini-pro</option>
+              <option value="GROK_1">Grok - grok-1</option>
             </select>
           </div>
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요
- 회원가입을 할 때 API 유효성을 검증한 후 회원가입이 가능하도록 하게 함.
- 회원가입 버튼이 비활성화 되어있다가, API 검증이 성공적으로 이루어지면 회원가입 버튼이 활성화 되도록 함.

# 어떻게 해결했나요
- UserController에 /validate-api-key POST 엔드포인트 추가. 요청 파라미터는 apiKey와 llmModel
- 회원가입 시 입력받은 API 키와 LLM 모델은 User Entity 정보(ApiKeyInfo)에 함께 저장됨.
- JS에서 fetch로 /validate-api-key 요청하며, 검증 후 응답에 따라 버튼 활성화 혹은 실패 메시지 렌더링.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- GPT-4o와 gemini-1.5-flash에 대해 검증 완료.
- grok과 claude는 유료 키 이슈로 검증하지 못했음. 호출 로직은 구현해 둠.
- 오류 발생 시 사용자에게 노출되는 메시지가 과도하거나 보기 싫은 건 아닌지.
- 우선은 gpt-4o, gpt-3.5-turbo, gemini-1.5-flash, gemini-pro, claude-3-opus, claude-3-haiku, grok-1에 대해서 지원하도록 구현해뒀음.
