### PR TITLE
Feat/31 log deployer test

### DIFF
--- a/triton_dashboard/src/test/java/com/triton/msa/triton_dashboard/log_deployer/service/DeployControllerTest.java
+++ b/triton_dashboard/src/test/java/com/triton/msa/triton_dashboard/log_deployer/service/DeployControllerTest.java
@@ -1,0 +1,47 @@
+package com.triton.msa.triton_dashboard.log_deployer.service;
+
+import org.apache.tika.metadata.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DeployController.class)
+class DeployControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LogDeployerService logDeployerService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그 수집기 배포 파일 다운로드")
+    void downloadConfig() throws Exception {
+        Long projectId = 10000L;
+        byte[] dummyZipBytes = "dummy-zip-content".getBytes();
+
+
+        given(logDeployerService.generateDeploymentZip(projectId)).willReturn(dummyZipBytes);
+
+        ResultActions resultActions = mockMvc.perform(get("/projects/{projectId}/deploy/download-config", projectId));
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"log-deploy-config-" + projectId + ".zip\""))
+                .andExpect(content().bytes(dummyZipBytes));
+    }
+}

--- a/triton_dashboard/src/test/java/com/triton/msa/triton_dashboard/log_deployer/service/LogDeployerServiceTest.java
+++ b/triton_dashboard/src/test/java/com/triton/msa/triton_dashboard/log_deployer/service/LogDeployerServiceTest.java
@@ -1,0 +1,41 @@
+package com.triton.msa.triton_dashboard.log_deployer.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogDeployerServiceTest {
+    private final LogDeployerService logDeployerService = new LogDeployerService();
+
+    @Test
+    @DisplayName("프로젝트 ID 기반 배포 명세 파일 생성")
+    void generateDeploymentZip() throws IOException{
+        Long projectId = 123L;
+
+        byte[] zipBytes = logDeployerService.generateDeploymentZip(projectId);
+
+        assertThat(zipBytes).isNotNull();
+        assertThat(zipBytes.length).isGreaterThan(0);
+
+        try(ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            assertThat(zis.getNextEntry().getName()).isEqualTo("01-namespace.yaml");
+            assertThat(zis.getNextEntry().getName()).isEqualTo("02-filebeat-config.yaml");
+            assertThat(zis.getNextEntry().getName()).isEqualTo("03-filebeat.yaml");
+            assertThat(zis.getNextEntry().getName()).isEqualTo("05-logstash.yaml");
+
+            assertThat(zis.getNextEntry().getName()).isEqualTo("04-logstash-config.yaml");
+
+            String logstashConfigContent = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(logstashConfigContent).contains("index => \"project-" + projectId + "-logs");
+
+            assertThat(zis.getNextEntry()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요

- log deployer 기능 테스트 코드 구현

# 어떻게 해결했나요

- LogDeployerServiceTest 구현
- DeployControllerTest 구현

# 어떤 부분에 집중하여 리뷰해야 할까요?

controller는 @WebMvc를 활용해 단위 테스트로 구현했고, service는 현재 순수 자바 코드 기반 테스트 방식으로 구현했습니다.