### PR TITLE
Refactor 42/improve printing

### DIFF
--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/controller/ChatController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/controller/ChatController.java
@@ -87,11 +87,11 @@ public class ChatController {
 
         return ragService.generateWithGeminiAsync(projectId, query)
                 .flatMapMany(fullResponse -> {
-                    // 토큰 단위로 쪼개기 (공백 포함, 줄바꿈 포함)
-                    String[] tokens = fullResponse.split("(?<= )|(?=\n)");
+                    // 토큰 단위로 쪼개기
+                    String[] tokens = fullResponse.split("(?<=\\n\\n)");
 
-                    return Flux.fromArray(tokens)
-                            .delayElements(Duration.ofMillis(20)) // 토큰 전송 속도
+                    return Flux.fromStream(fullResponse.chars().mapToObj(c -> String.valueOf((char) c)))
+                            .delayElements(Duration.ofMillis(5))
                             .doOnComplete(() -> {
                                 // 스트리밍 끝나면 DB 저장
                                 chatHistoryService.saveHistory(project, query, fullResponse);

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/entity/ChatHistory.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/entity/ChatHistory.java
@@ -29,7 +29,7 @@ public class ChatHistory {
     private String llmResponse;
 
     private LocalDateTime createdAt;
-
+    
     public ChatHistory(Project project, String title, String userQuery, String llmResponse) {
         this.project = project;
         this.title = title;

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/service/RagService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/service/RagService.java
@@ -49,7 +49,7 @@ public class RagService {
         String apiKey = userService.getUser(username).getApiKeyInfo().getApiServiceApiKey();
 
         if (apiKey == null || apiKey.isBlank()) {
-            return Mono.just("⚠️ API 키가 설정되지 않았습니다.");
+            return Mono.error(new RuntimeException("API 키가 설정되지 않았습니다."));
         }
 
         String url = "https://generativelanguage.googleapis.com/v1beta/models/"
@@ -72,11 +72,16 @@ public class RagService {
                         List<Map<String, Object>> candidates = (List<Map<String, Object>>) body.get("candidates");
                         Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
                         List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
-                        return (String) parts.get(0).get("text");
+                        String text = (String) parts.get(0).get("text");
+
+                        if (text == null || text.isBlank()) {
+                            throw new RuntimeException("응답이 비어있습니다.");
+                        }
+                        return text;
                     } catch (Exception e) {
-                        return "⚠️ 응답 파싱 실패";
+                        throw new RuntimeException("응답 파싱 실패");
                     }
                 })
-                .onErrorReturn("⚠️ 요청 실패");
+                .onErrorResume(e -> Mono.error(new RuntimeException("️요청 실패", e)));
     }
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/service/RagService.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/chat/service/RagService.java
@@ -94,7 +94,7 @@ public class RagService {
 
         return generateWithGeminiAsync(projectId, query)
                 .flatMapMany(fullResponse -> {
-                    String[] tokens = fullResponse.split("(?<=\\n)|(?=\\n)");
+                    String[] tokens = fullResponse.split("(?<=\\n)");
 
                     return Flux.fromArray(tokens)
                             .delayElements(Duration.ofMillis(20))

--- a/triton_dashboard/src/main/resources/static/css/style.css
+++ b/triton_dashboard/src/main/resources/static/css/style.css
@@ -32,17 +32,21 @@ body {
 
 /* ===== LLM 응답 스타일 ===== */
 .llm-response {
-    white-space: pre-wrap;
     word-break: break-word;
     background-color: #ffffff;
     padding: 18px 20px;
     border-radius: 12px;
-    font-family: 'Fira Code', 'Pretendard', 'Noto Sans KR', monospace;
+    font-family: 'Pretendard', 'Noto Sans KR', sans-serif;
     font-size: 15px;
-    line-height: 1.7;
+    line-height: 1.5;
     color: #2c2c2c;
     box-shadow: 0 2px 8px rgba(0,0,0,0.05);
     border: 1px solid #ececec;
+}
+
+/* 문단 간격 */
+.llm-response p {
+    margin: 0 0 8px;
 }
 
 /* 헤딩 */
@@ -58,7 +62,7 @@ body {
     padding-left: 22px;
 }
 .llm-response li {
-    margin-bottom: 6px;
+    margin-bottom: 4px;
 }
 
 /* 강조 */
@@ -71,14 +75,53 @@ body {
     font-style: italic;
 }
 
-/* 코드블록 */
+/* ===== 코드블럭 ===== */
+.llm-response pre {
+    background: #f6f8fa;
+    padding: 14px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 12px 0;
+    font-family: 'Fira Code', monospace;
+    font-size: 14px;
+}
 .llm-response code {
-    background-color: #f4f4f4;
-    padding: 2px 5px;
+    background: #f6f8fa;
+    padding: 2px 4px;
     border-radius: 4px;
     font-family: 'Fira Code', monospace;
     font-size: 14px;
     color: #d63384;
+}
+
+/* 코드블럭 복사 버튼 */
+.copy-btn {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: #f0f0f0;
+    border: none;
+    padding: 4px 6px;
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+.copy-btn:hover {
+    background: #ddd;
+}
+.code-block {
+    position: relative;
+}
+
+/* ===== 로딩 인디케이터 ===== */
+.typing-indicator {
+    font-style: italic;
+    color: #888;
+    animation: blink 1s infinite;
+}
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
 }
 
 /* ===== 채팅 버블 ===== */

--- a/triton_dashboard/src/main/resources/static/css/style.css
+++ b/triton_dashboard/src/main/resources/static/css/style.css
@@ -75,40 +75,72 @@ body {
     font-style: italic;
 }
 
-/* ===== 코드블럭 ===== */
+/* ===== 코드 블럭 ===== */
 .llm-response pre {
-    background: #f6f8fa;
-    padding: 14px;
+    background: #f6f8fa; /* 은은한 회색 */
+    padding: 14px 18px;
     border-radius: 8px;
     overflow-x: auto;
-    margin: 12px 0;
-    font-family: 'Fira Code', monospace;
+    font-family: 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
     font-size: 14px;
-}
-.llm-response code {
-    background: #f6f8fa;
-    padding: 2px 4px;
-    border-radius: 4px;
-    font-family: 'Fira Code', monospace;
-    font-size: 14px;
-    color: #d63384;
+    font-weight: 400;
+    line-height: 1.6;
+    color: #2d2d2d;
+    border: 1px solid #e1e4e8;
 }
 
-/* 코드블럭 복사 버튼 */
+/* 코드 블럭 안의 코드 */
+.llm-response pre code {
+    white-space: pre;
+    tab-size: 4;
+    -moz-tab-size: 4;
+}
+
+/* ===== 인라인 코드 ===== */
+.llm-response code:not(pre code) {
+    background: rgba(27,31,35,0.05);
+    color: #333;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-family: 'Fira Code', monospace;
+    font-weight: 500;
+}
+
+/* ===== 구문 하이라이팅 ===== */
+.llm-response .token.keyword { color: #6f42c1; font-weight: 500; }
+.llm-response .token.string { color: #a67f59; }
+.llm-response .token.comment { color: #6a737d; font-style: italic; }
+.llm-response .token.number { color: #b07c54; }
+.llm-response .token.function { color: #005cc5; }
+.llm-response .token.operator { color: #d73a49; }
+.llm-response .token.punctuation { color: #586069; }
+.llm-response .token.class-name,
+.llm-response .token.namespace,
+.llm-response .token.type {
+    color: #005cc5;
+}
+
+/* ===== Copy 버튼 ===== */
 .copy-btn {
     position: absolute;
-    top: 6px;
-    right: 8px;
-    background: #f0f0f0;
+    top: 8px;
+    right: 10px;
+    background: rgba(30, 30, 46, 0.85);
+    color: #fff;
     border: none;
-    padding: 4px 6px;
+    padding: 4px 8px;
     font-size: 12px;
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: 6px;
+    opacity: 0.8;
+    transition: all 0.2s ease;
 }
 .copy-btn:hover {
-    background: #ddd;
+    opacity: 1;
+    background: rgba(60, 60, 80, 0.95);
 }
+
 .code-block {
     position: relative;
 }

--- a/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
+++ b/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
@@ -1,7 +1,7 @@
 function renderMarkdownToElement(element, rawText) {
     if (!element) return;
 
-    // 코드블럭 렌더링
+    // 변환된 텍스트로 마크다운 렌더링
     let html = marked.parse(rawText || "", {
         highlight: function (code, lang) {
             if (lang && hljs.getLanguage(lang)) {
@@ -12,7 +12,7 @@ function renderMarkdownToElement(element, rawText) {
     });
     element.innerHTML = html;
 
-    // 코드블럭 복사 버튼 추가
+    // 코드 블럭 복사 버튼 추가
     element.querySelectorAll("pre code").forEach(block => {
         const parentPre = block.parentElement;
         if (!parentPre.classList.contains("code-block")) {

--- a/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
+++ b/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
@@ -1,0 +1,46 @@
+function renderMarkdownToElement(element, rawText) {
+    if (!element) return;
+
+    // 코드블럭 렌더링
+    let html = marked.parse(rawText || "", {
+        highlight: function (code, lang) {
+            if (lang && hljs.getLanguage(lang)) {
+                return hljs.highlight(code, { language: lang }).value;
+            }
+            return hljs.highlightAuto(code).value;
+        }
+    });
+    element.innerHTML = html;
+
+    // 코드블럭 복사 버튼 추가
+    element.querySelectorAll("pre code").forEach(block => {
+        const parentPre = block.parentElement;
+        if (!parentPre.classList.contains("code-block")) {
+            const wrapperDiv = document.createElement("div");
+            wrapperDiv.classList.add("code-block");
+            parentPre.replaceWith(wrapperDiv);
+            wrapperDiv.appendChild(parentPre);
+
+            const btn = document.createElement("button");
+            btn.className = "copy-btn";
+            btn.innerText = "Copy";
+            btn.onclick = () => {
+                navigator.clipboard.writeText(block.innerText);
+                btn.innerText = "Copied!";
+                setTimeout(() => btn.innerText = "Copy", 1500);
+            };
+            wrapperDiv.appendChild(btn);
+        }
+    });
+}
+
+// 과거 대화 내역용
+function renderMarkdownFromDataAttr(selector) {
+    document.querySelectorAll(selector).forEach(el => {
+        const raw = el.getAttribute("data-content") || "";
+        renderMarkdownToElement(el, raw);
+    });
+}
+
+window.renderMarkdownToElement = renderMarkdownToElement;
+window.renderMarkdownFromDataAttr = renderMarkdownFromDataAttr;

--- a/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
+++ b/triton_dashboard/src/main/resources/static/js/markdownRenderer.js
@@ -42,5 +42,9 @@ function renderMarkdownFromDataAttr(selector) {
     });
 }
 
+function clearTypingIndicator() {
+    document.querySelectorAll(".typing-indicator").forEach(el => el.remove());
+}
+
 window.renderMarkdownToElement = renderMarkdownToElement;
 window.renderMarkdownFromDataAttr = renderMarkdownFromDataAttr;

--- a/triton_dashboard/src/main/resources/templates/projects/chat-history-detail.html
+++ b/triton_dashboard/src/main/resources/templates/projects/chat-history-detail.html
@@ -8,6 +8,12 @@
   <meta charset="UTF-8">
   <title th:text="${history.title}">작업 이력 상세</title>
   <link rel="stylesheet" th:href="@{/css/style.css}">
+
+  <!-- Markdown + Highlight.js -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script src="/js/markdownRenderer.js"></script>
 </head>
 <body>
 <section layout:fragment="page-content">
@@ -19,23 +25,30 @@
       </p>
     </div>
 
+    <!-- 사용자 질문 -->
     <div class="d-flex justify-content-end mb-3">
       <div class="chat-bubble-user" th:text="${history.userQuery}"></div>
     </div>
 
+    <!-- LLM 응답 -->
     <div class="d-flex justify-content-start mb-3">
       <div class="chat-bubble-ai">
-        <h6 class="fw-bold mb-2">응답</h6>
-        <pre class="llm-response"
-             th:utext="${#strings.replace(#strings.replace(history.llmResponse, ' ', '&nbsp;'), '\n', '<br>')}">
-        </pre>
+        <div id="llm-response" class="llm-response" th:attr="data-content=${history.llmResponse}"></div>
       </div>
     </div>
 
     <a th:href="@{/projects/{projectId}/chat/history(projectId=${project.id})}"
-       class="btn btn-secondary btn-back mt-3">← 목록으로
+       class="btn btn-secondary btn-back mt-3">
+      ← 목록으로
     </a>
   </div>
 </section>
+<th:block layout:fragment="page-scripts">
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMarkdownFromDataAttr("#llm-response");
+    });
+  </script>
+</th:block>
 </body>
 </html>

--- a/triton_dashboard/src/main/resources/templates/projects/chat.html
+++ b/triton_dashboard/src/main/resources/templates/projects/chat.html
@@ -12,7 +12,14 @@
     <meta name="_csrf_header" th:content="${_csrf.headerName}" />
 
     <link rel="stylesheet" th:href="@{/css/style.css}">
+
+    <!-- Markdown + Highlight.js -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="/js/markdownRenderer.js"></script>
 </head>
+
 <body>
 <section layout:fragment="page-content">
     <div class="container-fluid p-4">
@@ -26,6 +33,7 @@
             </a>
         </div>
 
+        <!-- 채팅 히스토리 -->
         <div id="chat-window" class="border rounded p-3 mb-3 bg-white" style="height: 500px; overflow-y: auto;">
             <div th:each="msg : ${chatHistory}">
                 <div th:if="${msg.userQuery}" class="d-flex justify-content-end mb-2">
@@ -34,83 +42,101 @@
                 <div th:if="${msg.llmResponse}" class="d-flex justify-content-start mb-2">
                     <div class="chat-bubble-ai">
                         <h6 class="fw-bold mb-2">응답</h6>
-                        <pre class="llm-response" th:text="${msg.llmResponse}"></pre>
+                        <!-- 과거 응답은 data-content에 넣어 렌더링 -->
+                        <div class="llm-response" th:attr="data-content=${msg.llmResponse}"></div>
                     </div>
                 </div>
             </div>
         </div>
 
+        <!-- 입력창 -->
         <form id="chat-form">
             <div class="input-group">
                 <input type="text" id="query" name="query" class="form-control"
-                       placeholder="예: '레디스 3개 복제 배포 생성'" required>
+                       placeholder="예: '프로젝트 배포 명세 파일 생성해줘'" required>
                 <button class="btn btn-primary" type="submit">전송</button>
             </div>
         </form>
     </div>
 </section>
 <th:block layout:fragment="page-scripts">
-    <script>
-        let projectId = /*[[${project.id}]]*/ 0;
-        if (!projectId || projectId === 0) {
-            const match = window.location.pathname.match(/\/projects\/(\d+)\/chat/);
-            if (match) {
-                projectId = parseInt(match[1], 10);
+    <script th:inline="javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+            let projectId = /*[[${project.id}]]*/ 0;
+            if (!projectId) {
+                const match = window.location.pathname.match(/\/projects\/(\d+)\/chat/);
+                if (match) projectId = parseInt(match[1], 10);
             }
-        }
-        let eventSource = null;
 
-        document.getElementById("chat-form").addEventListener("submit", function (e) {
-            e.preventDefault();
-            const queryInput = document.getElementById("query");
-            const prompt = queryInput.value.trim();
-            if (!prompt) return;
             const chatWindow = document.getElementById("chat-window");
+            let eventSource = null;
 
-            if (eventSource) {
-                eventSource.close();
-                eventSource = null;
+            // 사용자 메시지 DOM 추가
+            function appendUserMessage(message) {
+                chatWindow.innerHTML += `
+                    <div class="d-flex justify-content-end mb-2">
+                        <div class="chat-bubble-user">${message}</div>
+                    </div>
+                `;
+                chatWindow.scrollTop = chatWindow.scrollHeight;
             }
 
-            // 유저 쿼리 렌더링
-            chatWindow.innerHTML += `
-                    <div class="d-flex justify-content-end mb-2">
-                        <div class="chat-bubble-user">${prompt}</div>
-                    </div>
-                `;
-            queryInput.value = "";
-
-            // 응답 블럭 추가
-            const wrapper = document.createElement("div");
-            wrapper.classList.add("d-flex", "justify-content-start", "mb-2");
-            wrapper.innerHTML = `
+            // LLM 응답 placeholder DOM 추가
+            function appendAIResponsePlaceholder() {
+                const wrapper = document.createElement("div");
+                wrapper.classList.add("d-flex", "justify-content-start", "mb-2");
+                wrapper.innerHTML = `
                     <div class="chat-bubble-ai">
-                        <h6 class="fw-bold mb-2">응답</h6>
-                        <pre class="llm-response"></pre>
+                        <div class="llm-response">
+                            <div class="typing-indicator">응답 생성 중...</div>
+                        </div>
                     </div>
                 `;
-            chatWindow.appendChild(wrapper);
+                chatWindow.appendChild(wrapper);
+                return wrapper.querySelector(".llm-response");
+            }
 
-            const explanationElem = wrapper.querySelector(".llm-response");
-            const url = `/projects/${projectId}/chat/stream?query=${encodeURIComponent(prompt)}`;
+            // SSE 연결 및 수신 후 렌더링
+            function renderStreamingResponse(prompt, explanationElem, loadingElem) {
+                let accumulatedText = "";
+                const url = `/projects/${projectId}/chat/stream?query=${encodeURIComponent(prompt)}`;
+                eventSource = new EventSource(url);
 
-            // /projects/{id}/chat/stream GET 요청을 (Server-Sent-Events)SSE 방식으로 보냄
-            eventSource = new EventSource(url);
+                eventSource.onmessage = function (event) {
+                    if (loadingElem) loadingElem.remove();
+                    accumulatedText += event.data;
+                    renderMarkdownToElement(explanationElem, accumulatedText);
+                    chatWindow.scrollTop = chatWindow.scrollHeight;
+                };
 
-            // LLM이 생성한 텍스트를 토큰 단위로 화면에 렌더링
-            eventSource.onmessage = function (event) {
-                const token = event.data
-                    .replace(/ /g, '&nbsp;')
-                    .replace(/\n/g, '<br>');
+                eventSource.onerror = function () {
+                    if (loadingElem) loadingElem.innerText = "⚠️ 응답 불가";
+                    eventSource.close();
+                    eventSource = null;
+                };
+            }
 
-                explanationElem.innerHTML += token;
-                chatWindow.scrollTop = chatWindow.scrollHeight;
-            };
+            // 폼 전송 이벤트
+            document.getElementById("chat-form").addEventListener("submit", function (e) {
+                e.preventDefault();
+                const queryInput = document.getElementById("query");
+                const prompt = queryInput.value.trim();
+                if (!prompt) return;
 
-            eventSource.onerror = function () {
-                eventSource.close();
-                eventSource = null;
-            };
+                // 기존 SSE 닫기
+                if (eventSource) {
+                    eventSource.close();
+                    eventSource = null;
+                }
+
+                appendUserMessage(prompt);
+                queryInput.value = "";
+
+                const explanationElem = appendAIResponsePlaceholder();
+                const loadingElem = explanationElem.querySelector(".typing-indicator");
+
+                renderStreamingResponse(prompt, explanationElem, loadingElem);
+            });
         });
     </script>
 </th:block>

--- a/triton_dashboard/src/main/resources/templates/projects/chat.html
+++ b/triton_dashboard/src/main/resources/templates/projects/chat.html
@@ -105,11 +105,14 @@
                 eventSource.onmessage = function (event) {
                     if (loadingElem) loadingElem.remove();
                     accumulatedText += event.data;
+
+                    // markdown 렌더링
                     renderMarkdownToElement(explanationElem, accumulatedText);
                     chatWindow.scrollTop = chatWindow.scrollHeight;
                 };
 
                 eventSource.onerror = function () {
+                    clearTypingIndicator();
                     if (loadingElem) loadingElem.innerText = "⚠️ 응답 불가";
                     eventSource.close();
                     eventSource = null;
@@ -128,6 +131,7 @@
                     eventSource.close();
                     eventSource = null;
                 }
+                clearTypingIndicator();
 
                 appendUserMessage(prompt);
                 queryInput.value = "";


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요
- LLM 응답 출력이 Markdown 문법을 적용하지 못하고 그대로 출력함
- 코드 블럭 별도 출력 및 복사하는 기능이 없음
- ChatController쪽 기능을 Service와 분리 필요
- chat.html의 js를 함수로 모듈화 필요

# 어떻게 해결했나요
- 응답을 Markdown 문법을 적용시킨 후 html로 출력
- 코드블럭 또한 코드블럭 테마 적용시키고, 코드 블럭 복사 버튼 추가
- ChatController와 RagService로 기능 분리
- chat.html과 chat-history-deatil.html에서 공통적으로 사용되는 js를 static/js/markdownRenderer.js로 분리
- chat.html에서 쓰이는 함수 또한 함수로 모듈화해서 분리

# 어떤 부분에 집중하여 리뷰해야 할까요
- LLM 출력이 예쁘고 가독성 좋게 출력이 되는지
- 추후 실제 RAG 파이프라인 응답으로 교체 예정
- 예외 또한 커스텀 예외로 바꿔서 전역적으로 처리할 수 있도록 변경할 예정