### PR TITLE
Feat/43 ssh client

### DIFF
--- a/triton_dashboard/build.gradle
+++ b/triton_dashboard/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// SSH 연결 - Apache MINA SSHD Core
 	implementation 'org.apache.sshd:sshd-core:2.12.1'
 
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// Apache Tika - 텍스트 추출용
 	implementation 'org.apache.tika:tika-core:3.2.1'
 	implementation 'org.apache.tika:tika-parsers-standard-package:3.2.1'

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/common/config/WebSocketConfig.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/common/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.triton.msa.triton_dashboard.common.config;
+
+import com.triton.msa.triton_dashboard.ssh.handler.SshWebSocketHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final SshWebSocketHandler sshWebSocketHandler;
+
+    public WebSocketConfig(SshWebSocketHandler sshWebSocketHandler) {
+        this.sshWebSocketHandler = sshWebSocketHandler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(sshWebSocketHandler, "/ws/ssh/{sessionId}")
+                .setAllowedOrigins("*");
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshApiController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshApiController.java
@@ -1,0 +1,33 @@
+package com.triton.msa.triton_dashboard.ssh.controller;
+
+import com.triton.msa.triton_dashboard.project.entity.Project;
+import com.triton.msa.triton_dashboard.project.service.ProjectService;
+import com.triton.msa.triton_dashboard.ssh.service.SshService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/ssh")
+public class SshApiController {
+    private final SshService sshService;
+    private final ProjectService projectService;
+
+    public SshApiController(SshService sshService, ProjectService projectService) {
+        this.sshService = sshService;
+        this.projectService = projectService;
+    }
+
+    @PostMapping("/connect/{projectId}")
+    public ResponseEntity<Map<String, String>> initiateSshConnection(@PathVariable Long projectId) {
+        Project project = projectService.getProject(projectId);
+
+        String sessionId = sshService.startSshSession(project.getSshInfo());
+
+        return ResponseEntity.ok(Map.of("sessionID", sessionId));
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshController.java
@@ -1,0 +1,34 @@
+package com.triton.msa.triton_dashboard.ssh.controller;
+
+import com.triton.msa.triton_dashboard.project.entity.Project;
+import com.triton.msa.triton_dashboard.project.repository.ProjectRepository;
+import com.triton.msa.triton_dashboard.project.service.ProjectService;
+import com.triton.msa.triton_dashboard.ssh.service.SshService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/ssh")
+public class SshController {
+    private final SshService sshService;
+    private final ProjectService projectService;
+
+    public SshController(SshService sshService, ProjectService projectService) {
+        this.sshService = sshService;
+        this.projectService = projectService;
+    }
+
+    @PostMapping("/connect/{projectId}")
+    public ResponseEntity<Map<String, String>> initiateSshConnection(@PathVariable Long projectId) {
+        Project project = projectService.getProject(projectId);
+
+        String sessionId = sshService.startSshSession(project.getSshInfo());
+
+        return ResponseEntity.ok(Map.of("sessionID", sessionId));
+    }
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshController.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/controller/SshController.java
@@ -1,34 +1,19 @@
 package com.triton.msa.triton_dashboard.ssh.controller;
 
-import com.triton.msa.triton_dashboard.project.entity.Project;
-import com.triton.msa.triton_dashboard.project.repository.ProjectRepository;
-import com.triton.msa.triton_dashboard.project.service.ProjectService;
-import com.triton.msa.triton_dashboard.ssh.service.SshService;
-import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
-@RestController
-@RequestMapping("/api/ssh")
+@Controller
+@RequestMapping("/ssh")
 public class SshController {
-    private final SshService sshService;
-    private final ProjectService projectService;
 
-    public SshController(SshService sshService, ProjectService projectService) {
-        this.sshService = sshService;
-        this.projectService = projectService;
-    }
+    @GetMapping("/connect/{projectId}")
+    public String sshConnectUI(@PathVariable String projectId, Model model) {
+        model.addAttribute("projectId", projectId);
 
-    @PostMapping("/connect/{projectId}")
-    public ResponseEntity<Map<String, String>> initiateSshConnection(@PathVariable Long projectId) {
-        Project project = projectService.getProject(projectId);
-
-        String sessionId = sshService.startSshSession(project.getSshInfo());
-
-        return ResponseEntity.ok(Map.of("sessionID", sessionId));
+        return "ssh/ssh-client";
     }
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/handler/SshWebSocketHandler.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/handler/SshWebSocketHandler.java
@@ -1,8 +1,84 @@
 package com.triton.msa.triton_dashboard.ssh.handler;
 
+import com.triton.msa.triton_dashboard.ssh.service.SshConnectionDetails;
+import com.triton.msa.triton_dashboard.ssh.service.SshService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 @Component
+@Slf4j
 public class SshWebSocketHandler extends TextWebSocketHandler {
+
+    private final SshService sshService;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    public SshWebSocketHandler(SshService sshService) {
+        this.sshService = sshService;
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        String sessionId = extractSessionId(session);
+        SshConnectionDetails details = sshService.findSessionDetails(sessionId);
+
+        if(details == null) {
+            log.warn("WebSocket 연결 시도, 유효하지 않은 세션 ID: {}", sessionId);
+            closeSessionWithError(session, "유효하지 않은 세션 ID입니다.");
+            return;
+        }
+
+        executorService.submit(() -> {
+            try{
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = details.shellOut().read(buffer)) != -1 && session.isOpen()) {
+                    session.sendMessage(new TextMessage(new String(buffer, 0, bytesRead)));
+                }
+            }
+            catch (IOException e) {
+                if(!"Pipe closed".equalsIgnoreCase(e.getMessage())) {
+                    log.error("SSH 출력 스트림 읽기 오류 (세션 ID: {}): {}", sessionId, e.getMessage());
+                }
+            }
+            finally {
+                sshService.closeSshSession(sessionId);
+            }
+        });
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+        String sessionId = extractSessionId(session);
+        sshService.sendCommand(sessionId, message.getPayload());
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        String sessionId = extractSessionId(session);
+        sshService.closeSshSession(sessionId);
+        log.info("WebSocket 연결 종료 (세션 ID: {}), 상태: {}", sessionId, status);
+    }
+
+    private String extractSessionId(WebSocketSession session) {
+        String path = Objects.requireNonNull(session.getUri()).getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    private void closeSessionWithError(WebSocketSession session, String reason) {
+        try {
+            session.close(CloseStatus.SERVER_ERROR.withReason(reason));
+        }
+        catch (IOException ex) {
+            log.error("에러 발생 후 WebSocket 세션 닫기 실패", ex);
+        }
+    }
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/handler/SshWebSocketHandler.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/handler/SshWebSocketHandler.java
@@ -1,0 +1,8 @@
+package com.triton.msa.triton_dashboard.ssh.handler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+public class SshWebSocketHandler extends TextWebSocketHandler {
+}

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshConnectionDetails.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshConnectionDetails.java
@@ -10,8 +10,8 @@ import java.nio.file.Path;
 public record SshConnectionDetails(
         ClientSession session,
         ChannelShell channelShell,
-        PipedOutputStream outputStream,
-        PipedInputStream inputStream,
+        PipedOutputStream ptyOut,
+        PipedInputStream shellOut,
         Path tempKeyPath
 ) {
 }

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshConnectionDetails.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/ssh/service/SshConnectionDetails.java
@@ -1,0 +1,17 @@
+package com.triton.msa.triton_dashboard.ssh.service;
+
+import org.apache.sshd.client.channel.ChannelShell;
+import org.apache.sshd.client.session.ClientSession;
+
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.file.Path;
+
+public record SshConnectionDetails(
+        ClientSession session,
+        ChannelShell channelShell,
+        PipedOutputStream outputStream,
+        PipedInputStream inputStream,
+        Path tempKeyPath
+) {
+}

--- a/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
+++ b/triton_dashboard/src/main/resources/templates/fragments/sidebar.html
@@ -27,6 +27,10 @@
                th:href="@{/projects/{id}/private-data(id=${project.id})}">
                 <i class="bi bi-shield-lock me-2"></i>비공개 데이터 관리
             </a>
+            <a class="list-group-item list-group-item-action list-group-item-light p-3"
+               th:href="@{/ssh/connect/{projectId}(projectId=${project.id})}">
+                <i class="bi bi-diagram-2 me-2"></i>서비스 원격 접속
+            </a>
             <hr class="my-2"/>
             <a class="list-group-item list-group-item-action list-group-item-light p-3"
                th:href="@{/projects}">

--- a/triton_dashboard/src/main/resources/templates/layout/layout.html
+++ b/triton_dashboard/src/main/resources/templates/layout/layout.html
@@ -9,6 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsDelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" th:href="@{/css/style.css}">
+    <th:block layout:fragment="css"></th:block>
 </head>
 
 <body>
@@ -16,11 +17,11 @@
 <div class="d-flex" id="wrapper">
     <div th:replace="~{fragments/sidebar :: sidebar(project=${project})}"></div>
 
-    <div id="page-content-wrapper">
+    <div id="page-content-wrapper" class="d-flex flex-column">
         <nav th:replace="~{fragments/header :: header}"></nav>
 
-        <main class="container-fluid">
-            <section layout:fragment="page-content"></section>
+        <main class="container-fluid flex-grow-1 d-flex flex-column">
+            <section layout:fragment="page-content" class="flex-grow-1 d-flex flex-column"></section>
         </main>
     </div>
 </div>

--- a/triton_dashboard/src/main/resources/templates/ssh/ssh-client.html
+++ b/triton_dashboard/src/main/resources/templates/ssh/ssh-client.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/triton_dashboard/src/main/resources/templates/ssh/ssh-client.html
+++ b/triton_dashboard/src/main/resources/templates/ssh/ssh-client.html
@@ -1,10 +1,110 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="layout/layout">
 
-</body>
+<th:block layout:fragment="title">SSH Client</th:block>
+
+<th:block layout:fragment="css">
+    <link href=" https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css " rel="stylesheet">
+    <style>
+        #terminal-container {
+            width: 100%;
+            height: 100%;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+        #terminal {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="page-content">
+    <h2 class="mb-3">📜 서비스 원격 접속</h2>
+    <div id="terminal-container">
+        <div id="terminal"></div>
+    </div>
+</div>
+
+<th:block layout:fragment="page-scripts">
+    <script src=" https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js "></script>
+    <script th:inline="javascript">
+        document.addEventListener("DOMContentLoaded", function() {
+            const term = new Terminal({
+                cursorBlink: true,
+                fontSize: 14,
+                fontFamily: 'Consolas, "Courier New", monospace',
+                theme: {
+                    background: '#1e1e1e',
+                    foreground: '#d4d4d4',
+                    cursor: '#ffffff',
+                    selectionBackground: '#264f78'
+                }
+            });
+            term.open(document.getElementById('terminal'));
+
+            const projectId = /*[[${projectId}]]*/'';
+
+            if(!projectId) {
+                term.write("\x1b[31mError: Project ID가 지정되지 않았습니다.\x1b[0m\r\n");
+                return;
+            }
+
+            term.write('connecting server via triton...\r\n');
+            let ws;
+
+            fetch(`/api/ssh/connect/${projectId}`, { method: 'POST'})
+                .then(response => {
+                    if(!response.ok) {
+                        return response.json().then(errorBody => {
+                            throw new Error(errorBody.message || 'Unknown Server Error');
+                        });
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    const sessionId = data.sessionId;
+                    if (!sessionId) {
+                        throw new Error('서버로부터 세션 ID를 받지 못했습니다.');
+                    }
+
+                    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+                    const host = window.location.host;
+                    const wsUrl = `${protocol}//${host}/ws/ssh/${sessionId}`;
+
+                    ws = new WebSocket(wsUrl);
+
+                    ws.onopen = () => {
+                        term.write('\x1b[32mSSH 연결 성공!\x1b[0m\r\n');
+                        term.focus();
+                    };
+
+                    ws.onmessage = (event) => {
+                        term.write(event.data);
+                    };
+
+                    ws.onclose = (event) => {
+                        term.write(`\r\n\x1b[33m연결이 종료되었습니다. 코드: ${event.code}, 이유: ${event.reason || '없음'}\x1b[0m\r\n`);
+                    };
+
+                    ws.onerror = (error) => {
+                        term.write('\r\n\x1b[31mWebSocket 오류가 발생했습니다.\x1b[0m\r\n');
+                        console.error('WebSocket Error: ', error);
+                    };
+
+                    term.onData(data => {
+                        if(ws && ws.readyState === WebSocket.OPEN) {
+                            ws.send(data);
+                        }
+                    });
+                })
+                .catch(error => {
+                    console.error('SSH 연결 시작 오류:', error);
+                    term.write(`\r\n\x1b[31m연결 실패: ${error.message}\x1b[0m\r\n`);
+                })
+        })
+    </script>
+</th:block>
 </html>


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요

- websocket을 활용한 웹 기반 ssh 접속 터미널 구현

# 어떻게 해결했나요

- SSH 세션을 메모리 상에서 ConcurrentHashMap으로 관리
- SSH WebSocket Handler 구현
- Websocket 기반 양방향 통신

# 어떤 부분에 집중하여 리뷰해야 할까요?

SshClient의 로직을 최대한 직관적으로 작성하려고 노력했습니다. 
websocket 기반으로 양방향 통신이 가능한 터미널을 사용하기 위해 프론트단에서 xterm를 사용했습니다.
현재 프로젝트 생성 시 SSH 접속을 위한 정보 입력 폼이 완전하지 않아서 현재 실제 접속 가능한지 테스트 불가능한 상황입니다.