### PR TITLE
Feat 124/rag data

### DIFF
--- a/rag_server/app/chain_query.py
+++ b/rag_server/app/chain_query.py
@@ -3,11 +3,15 @@ from datetime import datetime, date
 from flask import Response, stream_with_context
 from langchain.chains import RetrievalQA
 from langchain_core.runnables import RunnablePassthrough
+from langchain_core.runnables import RunnableParallel
 from langchain_core.output_parsers import StrOutputParser
+from langchain_core.output_parsers import JsonOutputParser
 import chain_components
 
 def format_docs(docs):
-    return "\n\n".join(f"- {d.page_content}" for d in docs)
+    return "\n\n".join(
+        f"[source_{i+1}]: {d.page_content}" for i, d in enumerate(docs)
+    )
 
 def _json_safe(val):
     """JSON으로 직렬화 가능한 값으로 변환"""
@@ -26,68 +30,82 @@ def _jline(obj: dict) -> bytes:
     # 혹시 남아 있는 비직렬 타입이 있어도 막아주기
     return (json.dumps(_json_safe(obj), ensure_ascii=False) + "\n").encode("utf-8")
 
-def query_rag(query: str, index_name: str, query_type: str, provider: str, llm: str, api_key: str) -> dict:
-    rag_chain = create_rag_chain(index_name, query_type, provider, llm, api_key)
+def create_rag_chain_with_attribution(index_name: str, query_type: str, provider: str, llm: str, api_key: str):
     
-    result = rag_chain.invoke(
-        {"query": query},
-    )
-    answer = result["result"]
-    
-    #query: 사용자 질문, answer: RAG 기반 답변, sources: 참조한 문서
-    return {
-        "question": query,
-        "answer": answer,
-        "sources": [doc.page_content for doc in result["source_documents"]],
-        "log": f"response was created by {llm} of {provider} using {query_type} template"
-    }
-
-def query_rag_stream(query: str, index_name: str, query_type: str, provider: str, llm: str, api_key: str) -> Response:
-    rag_chain = create_rag_chain_stream(index_name, query_type, provider, llm, api_key)
-    started_at = time.time()
-    
+    # 1. 컴포넌트 가져오기 (기존과 동일)
     embedding_model = chain_components.get_embedding_model()
     vectorstore = chain_components.get_vectorstore(index_name, embedding_model)
-    retriever = vectorstore.as_retriever()
+    retriever = vectorstore.as_retriever(search_kwargs={"k": 20})
+    chat_llm = chain_components.get_chat_llm(provider, llm, api_key)
+    prompt_tmpl = chain_components.get_prompt_tmpl(query_type)
     
-    def generate():
-        # 1) 소스 먼저
-        # docs = retriever.get_relevant_documents(query)
-        # sources = [
-        #     {
-        #         "snippet": d.page_content[:200],
-        #         "metadata": getattr(d, "metadata", {}),
-        #     }
-        #     for d in docs
-        # ]
-        # yield _jline({"event": "sources", "data": sources})
-
-        # 2) 토큰 스트리밍
-        answer_acc = []
-        last_beat = time.time()
-        for chunk in rag_chain.stream(query):
-            if chunk:
-                answer_acc.append(chunk)
-                print(chunk)
-                yield _jline({"event": "token", "data": chunk})
-            if time.time() - last_beat > 15:
-                yield _jline({"event": "heartbeat"})
-                last_beat = time.time()
-
-        final_answer = "".join(answer_acc)
-        latency_ms = int((time.time() - started_at) * 1000)
-
-        # 3) 완료 신호
-        yield _jline({"event": "done", "data": {"answer": "".join(answer_acc)}})
-        print(f"response was created by {llm} of {provider} using {query_type} template")
-
-    headers = {
-            "Content-Type": "application/jsonl; charset=utf-8",
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
+    # 2. 메인 생성 체인 정의
+    # 이 체인은 'source_documents'와 'question'을 입력받아 JSON을 출력합니다.
+    generation_chain = (
+        {
+            "context": lambda x: format_docs(x["source_documents"]),
+            "question": lambda x: x["question"]
         }
-    return Response(stream_with_context(generate()), headers=headers, status=200)
+        | prompt_tmpl
+        | chat_llm
+        | JsonOutputParser()
+    )
+
+    # 3. 최종 체인 정의 (RunnableParallel 사용)
+    # retriever를 두 번 사용하여 한 번은 생성 체인으로, 한 번은 최종 출력으로 전달합니다.
+    final_chain = RunnableParallel(
+        llm_output= {"source_documents": retriever, "question": RunnablePassthrough()} | generation_chain,
+        source_documents=retriever,
+    )
+    
+    return final_chain
+
+# def query_rag(query: str, index_name: str, query_type: str, provider: str, llm: str, api_key: str) -> dict:
+#     rag_chain = create_rag_chain(index_name, query_type, provider, llm, api_key)
+    
+#     result = rag_chain.invoke(
+#         {"query": query},
+#     )
+#     answer = result["result"]
+    
+#     #query: 사용자 질문, answer: RAG 기반 답변, sources: 참조한 문서
+#     return {
+#         "question": query,
+#         "answer": answer,
+#         "sources": [doc.page_content for doc in result["source_documents"]],
+#         "log": f"response was created by {llm} of {provider} using {query_type} template"
+#     }
+
+
+def query_rag(query: str, index_name: str, query_type: str, provider: str, llm: str, api_key: str) -> dict:
+    if query_type == "yaml_generation":
+        rag_chain = create_rag_chain_with_attribution(index_name, query_type, provider, llm, api_key)
+        
+        result = rag_chain.invoke(query)
+
+        # 중첩된 llm_output 딕셔너리를 먼저 가져옵니다.
+        # .get("llm_output", {})는 llm_output이 없을 경우를 대비한 안전장치입니다.
+        llm_output = result.get("llm_output", {})
+        
+        # llm_output 딕셔너리 안에서 'yaml'과 'attributions'를 찾습니다.
+        return {
+            "question": query,
+            "answer": llm_output.get("yaml"), 
+            "attributions": llm_output.get("attributions"),
+            "sources": [doc.page_content for doc in result.get("source_documents", [])],
+            "log": f"response was created by {llm} of {provider} using {query_type} template with attribution"
+        }
+    else:
+        # 'yaml_generation'이 아닐 때의 기존 로직은 문제가 없으므로 그대로 둡니다.
+        rag_chain = create_rag_chain(index_name, query_type, provider, llm, api_key)
+        result = rag_chain.invoke({"query": query})
+        
+        return {
+            "question": query,
+            "answer": result.get("result"),
+            "sources": [doc.page_content for doc in result.get("source_documents", [])],
+            "log": f"response was created by {llm} of {provider} using {query_type} template"
+        }
 
 #해당 index를 참조하는 chain 생성
 def create_rag_chain(index_name: str, query_type: str, provider: str, llm: str, api_key: str):
@@ -112,30 +130,5 @@ def create_rag_chain(index_name: str, query_type: str, provider: str, llm: str, 
         return_source_documents=True,
         chain_type="stuff",
         chain_type_kwargs={"prompt": prompt_tmpl},
-    )
-    return rag_chain
-
-# 스트리밍용
-def create_rag_chain_stream(index_name: str, query_type: str, provider: str, llm: str, api_key: str):
-    
-    # 1. 임베딩(OpenAI 고정)
-    embedding_model = chain_components.get_embedding_model()
-    
-    # 2. 벡터스토어
-    vectorstore = chain_components.get_vectorstore(index_name, embedding_model)
-    retriever = vectorstore.as_retriever()
-    
-    # 3. LLM 선택
-    chat_llm = chain_components.get_chat_llm(provider, llm, api_key)
-    
-    # 4. 프롬프트
-    prompt_tmpl = chain_components.get_prompt_tmpl(query_type)
-    
-    # 5. 체인
-    rag_chain = (
-        {"context": retriever | format_docs, "question": RunnablePassthrough()}
-        | prompt_tmpl
-        | chat_llm
-        | StrOutputParser()
     )
     return rag_chain

--- a/rag_server/app/embedding.py
+++ b/rag_server/app/embedding.py
@@ -10,7 +10,7 @@ es_client = Elasticsearch(es_url)
 embedding_model = OpenAIEmbeddings()
 text_splitter = CharacterTextSplitter.from_tiktoken_encoder(
     separator="\n",
-    chunk_size = 600,
+    chunk_size = 512,
     chunk_overlap = 100,
 )
 

--- a/rag_server/app/main.py
+++ b/rag_server/app/main.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from embedding import embed_and_store
 from embedding import delete_by_file_name
-from chain_query import query_rag, query_rag_stream
+from chain_query import query_rag
 from settings import settings
 
 app = Flask(__name__)
@@ -39,24 +39,7 @@ def get_rag_response():
         response_data = query_rag(query, es_index, query_type, provider, model, api_key)
         return jsonify(response_data), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
-@app.route("/api/get-rag-response-stream", methods=["POST"])
-def get_rag_response_stream():    
-    data = request.json or {}
-    query = data.get("query")
-    es_index = data.get("es_index", "default")
-    query_type = data.get("query_type", "default")
-    provider = data.get("provider", "openai")
-    model = data.get("model", "gpt-4o-mini")
-
-    if not query:
-        return jsonify({"error": "query is empty."}), 400
-    
-    try:
-        # query_rag_stream 함수가 스트리밍 응답을 생성합니다.
-        return query_rag_stream(query, es_index, query_type, provider, model)
-    except Exception as e:
+        print(f"An error occurred: {e}")
         return jsonify({"error": str(e)}), 500
     
 # 문서 embedding 후 ElasticSearch에 저장하는 API

--- a/rag_server/app/prompt_template.py
+++ b/rag_server/app/prompt_template.py
@@ -4,7 +4,7 @@ yaml_generation_prompt = PromptTemplate(
     input_variables=["context", "question"],
     template="""
         당신은 클라우드 애플리케이션 배포에 능숙한 Kubernetes 전문가입니다.
-        아래의 문맥과 사용자 요구사항을 기반으로 Kubernetes 클러스터에 실제로 배포 가능한 YAML 명세를 생성하세요.
+        아래의 문맥과 사용자 요구사항을 기반으로 Kubernetes 클러스터에 배포 가능한 YAML 명세와 그 출처를 JSON 형식으로 생성하세요.
 
         문맥:
         {context}
@@ -13,14 +13,23 @@ yaml_generation_prompt = PromptTemplate(
         {question}
 
         작성 규칙:
-        - 전체 결과를 **YAML 형식**으로 출력하세요.
-        - 각 필드의 역할을 **간단한 주석** 으로 설명하세요.
-        - 기본적인 리소스 설정을 포함하세요:
-        - `replicas`, `containerPort`, `resources.limits/requests` 등
-        - 필요한 경우 다음과 같은 리소스도 함께 생성하세요:
-        - `Service`, `Deployment`, `ConfigMap`, `PersistentVolumeClaim`
-        - 생성된 YAML은 실제 배포 가능한 형식이어야 합니다.
-        - 하나의 YAML 안에 여러 리소스가 필요한 경우 `---` 로 구분해서 함께 정의하세요.
+        - 반드시 하나의 JSON 객체만을 출력해야 합니다.
+        - JSON 객체는 'yaml'과 'attributions' 두 개의 키를 가져야 합니다.
+        - 'yaml' 키의 값은 전체 Kubernetes YAML 명세를 담은 단일 문자열입니다.
+        
+        - **중요: 'yaml' 문자열의 내용은 반드시 마크다운 YAML 코드 블럭(```yaml)으로 감싸야 합니다.**
+        
+        - 'attributions' 키의 값은 각 소스(e.g., 'source_1')가 YAML 생성에 어떻게 기여했는지를 설명하는 객체입니다.
+        - 각 필드의 역할은 YAML 내에 간단한 주석으로 설명하세요.
+
+        JSON 출력 예시:
+        {{
+            "yaml": "```yaml\\napiVersion: apps/v1\\nkind: Deployment\\nmetadata:\\n  name: my-app\\nspec:\\n  replicas: 3 # From source_2\\n...\\n```",
+            "attributions": {{
+                "source_1": "Deployment의 기본 구조와 metadata 부분을 생성하는 데 사용되었습니다.",
+                "source_2": "replicas 수를 3으로 설정하는 요구사항을 반영하는 데 사용되었습니다."
+            }}
+        }}
     """
 )
 

--- a/triton_dashboard/src/main/resources/templates/projects/private-data.html
+++ b/triton_dashboard/src/main/resources/templates/projects/private-data.html
@@ -55,7 +55,7 @@
         <ul class="list-group list-group-flush">
           <li th:each="file : ${uploadResult.savedFilenames}" class="list-group-item ps-4">
             <i class="bi bi-file-earmark-text me-2 text-secondary"></i>
-            <span th:text="${file}"></span>
+            <span th:text="${file.filename}"></span>
           </li>
         </ul>
       </div>
@@ -68,7 +68,7 @@
         <ul class="list-group list-group-flush">
           <li th:each="file : ${uploadResult.skippedFilenames}" class="list-group-item ps-4">
             <i class="bi bi-x-circle text-danger me-2"></i>
-            <span th:text="${file}"></span>
+            <span th:text="${file.filename} + ' - ' + ${file.reason}"></span>
           </li>
         </ul>
         <p class="text-muted small mt-2">


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요
- 비공개 데이터 업로드 시, 성공과 실패에 대한 메시지가 UploadResultDto 내용 그대로 출력되는 문제
- 생성된 YAML의 특정 부분이 어떤 소스 문서를 참조했는지 추적할 수 없는 출처 불분명 문제

# 작업 상세 내용
- prompt_template.py : YAML 생성 프롬프트 수정: 구조화된 JSON 출력 요구
- LLM이 단순 텍스트가 아닌, yaml과 attributions 두 개의 키를 가진 JSON 객체를 반환하도록 프롬프트를 수정했습니다.
- yaml 키에는 최종 YAML 문자열이, attributions 키에는 각 소스 문서가 YAML 생성에 어떻게 참조 되었는지에 대한 설명이 포함됩니다.
- yaml에서 내용 생성을 위해 참조된 부분은 주석으로 # from source 9 이렇게 나타나집니다. 이는 9번째 내부 데이터 청크를 참고했다는 의미입니다.
- attributions에는 yaml 내용 생성을 위해 참조된 내부 데이터 청크가 어떻게 참조되었는지(예: Source 11: 서비스 간 의존 관계를 이해하고 구성하는 데 사용되었습니다.)가 설명됩니다.
- 이 모든 과정이 RAG 프롬프트와 이에 따른 LLM의 판단에 의해 진행되기 때문에, 이 과정은 모두 LLM에 의존해야 하며 이로 인해 정확성에 대한 불확실성이 생길 수 있습니다. 다른 방안이 있는지에 대해서 강구해봐야 겠지만, 현실적으로는 힘든 것 같습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 시간이 부족해서, 코드에 대한 이해가 부족한 상태로 작성되었습니다.
- 답변 생성 시간이 오래 걸려서 추후 검토를 해봐야 합니다. 
- yaml에서 해당 내용이 생성되기 위해 참조된 내부 데이터 청크가 무엇인지 매핑시킬려면 답변 생성 시간이 오래 걸리는 것은 필연적인 것 같습니다.