### PR TITLE
API 키 인코딩 ë° 저장 및 디코딩 반환 로직 추가 및 DB URL 추가 #140

### DIFF
--- a/triton_dashboard/.env
+++ b/triton_dashboard/.env
@@ -1,0 +1,3 @@
+DB_URL=jdbc:mysql://triton-dashboard-db.cbi0maoeq5ae.ap-southeast-2.rds.amazonaws.com:3306/triton-dashboard-db
+DB_USERNAME=triton1234
+DB_PASSWORD=triton78941236

--- a/triton_dashboard/build.gradle
+++ b/triton_dashboard/build.gradle
@@ -62,7 +62,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	
+
+	// RDS MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	implementation 'org.springframework.security:spring-security-crypto'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/ApiKeyEncryptor.java
+++ b/triton_dashboard/src/main/java/com/triton/msa/triton_dashboard/user/util/ApiKeyEncryptor.java
@@ -1,0 +1,36 @@
+package com.triton.msa.triton_dashboard.user.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class ApiKeyEncryptor {
+
+    private final AesBytesEncryptor encryptor;
+
+    public ApiKeyEncryptor(@Value("${api.key.encryption.password}") String password,
+                           @Value("${api.key.encryption.salt}") String salt) {
+        this.encryptor = new AesBytesEncryptor(password, salt);
+    }
+
+    public String encrypt(String apiKey) {
+        if (apiKey == null) {
+            return null;
+        }
+        byte[] encrypt = encryptor.encrypt(apiKey.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(encrypt);
+    }
+
+    public String decrypt(String encryptedApiKey) {
+        if (encryptedApiKey == null) {
+            return null;
+        }
+        byte[] decryptBytes = Base64.getDecoder().decode(encryptedApiKey);
+        byte[] decrypted = encryptor.decrypt(decryptBytes);
+        return new String(decrypted, StandardCharsets.UTF_8);
+    }
+}

--- a/triton_dashboard/src/main/resources/application-dev.properties
+++ b/triton_dashboard/src/main/resources/application-dev.properties
@@ -6,3 +6,12 @@ elasticsearch.host=${ELASTICSEARCH_HOST:localhost}
 elasticsearch.port=${ELASTICSEARCH_PORT:9200}
 
 monitoring.scheduler.rate=${MONITORING_SCHEDULER_RATE:60000}
+
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+api.key.encryption.password = 9y!Qm7Gd$Pj4xL2cVw@R8sNt#Zb5Kf1o
+api.key.encryption.salt = a13f7c8d9b4e6f02


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요
- AWS RDS에 MySQL을 배포하고 스프링 프로젝트와 연결
- DB가 AWS에 배포됨에 따라, 사용자 API키 암호화 필요성 대두

# 작업 상세 내용
- AWS RDS에 MySQL을 배포하고, 스프링 프로젝트와 연결 했습니다.
- 현재 보안 인바운드 정책을, 모든 IP에 대해서 허용하도록 해놨습니다. 개발 환경을 위한 것으로, 나중에 수정이 필요합니다.
- 사용자 API 키를 AES 암호화 알고리즘으로 암호화해서 DB에 저장하고, 조회할 때 복호화해서 반환하는 로직을 추가했습니다. 

# 어떤 부분에 집중하여 리뷰해야 할까요?
- DB 연결에 따른 application 설정 파일 및 .env 파일 항목 내용은 문의하면 제공해드리겠습니다.
- 이제 사용자 정보가 AWS RDS에 저장됨에 따라, 회원정보 수정 및 탈퇴 기능이 필요해졌습니다. 현재 해당 기능이 없는 관계로, 회원 탈퇴 후 새로 만들고 싶으면 MySQL Workbench에서 수작업으로 지워야 하는 번거로움이 있습니다.
- 현재 DB 엔드포인트와 username, password만 있으면 전세계 모든 IP에서 우리 DB에 접근할 수 있습니다. 
- 이를 막기 위해서는 보안 그룹의 인바운드 규칙에 모든 IP 접근 허용 규칙을 제거하고 접근을 허용할 특정 IP를 추가해주어야 합니다.
- 하지만, 학교에서 작업을 하게 되면 IP가 계속 바뀌어서 특정 IP만 접근 허용하게 하는 것은 번거롭다고 판단했습니다. 추후 배포를 하게된다면 해당 규칙은 바뀌어야 합니다.